### PR TITLE
チャットの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -72,7 +72,7 @@ $(document).on('turbolinks:load', function(){
       }
     })
     .fail(function(){
-      console.log('error');
+      alert('error');
     });
   };
   setInterval(reloadMessages, 7000);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,8 @@
-$(document).on('turbolinks:load', function(){
+$(document).on('turbolinks:load', function(){ 
   function buildmessage(message){
     var content = message.content ? `${message.content}`: "";
     var img = message.image ? `<img src= ${message.image}>` : "";
-    var html = `<div class="message" data-id="${message.id}">
+    var html = `<div class="message" data-message-id="${message.id}">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                     ${message.user_name}
@@ -48,4 +48,32 @@ $(document).on('turbolinks:load', function(){
       $('.form__submit').prop('disabled', false);
     })
   })
+
+  var reloadMessages = function(){
+    if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  }
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax ({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages){
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message){
+        insertHTML += buildmessage(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $("#new_message")[0].reset();
+        $(".form__submit").prop("disabled", false);
+      }
+    })
+    .fail(function(){
+      console.log('error');
+    });
+  };
+  setInterval(reloadMessages, 7000);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+
+    last_message_id = params[:id].to_i
+    
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
-json.content  @message.content
-json.id  @message.id
-json.date  @message.created_at.strftime("%Y/%m/%d(%a) %H:%M")
-json.user_name  @message.user.name
-json.image  @message.image.url
+json.content    @message.content
+json.image      @message.image.url
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end  
   end
 end


### PR DESCRIPTION
# What
チャットの自動更新を実装する。
Ajax、コントローラー、モデル、jBuilderの連携によって実装していく。
# Why
Lineなどのチャットツールのように、相手からのメッセージが自動でブラウザに反映されるようにするため。
#画像です。
https://gyazo.com/04648601a8701704c385bfb0bc1253e4